### PR TITLE
Correct URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hanchon/evmosjs",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "Evmosjs javascript lib for the evmos blockchain",
     "license": "MIT",
     "repository": "hanchon-live/evmosjs",

--- a/src/rest/claims.ts
+++ b/src/rest/claims.ts
@@ -35,7 +35,7 @@ export async function getTotalUnclaimed(client: RestInstance) {
 
 export async function getClaimsRecord(client: RestInstance, address: string) {
     try {
-        let res = await client.get(`/evmos/claims/v1/claims_record/${address}`)
+        let res = await client.get(`/evmos/claims/v1/claims_records/${address}`)
         return parseClaimsRecord(res.data, address)
     } catch (e: any) {
         return {

--- a/tests/rest/claims.spec.ts
+++ b/tests/rest/claims.spec.ts
@@ -48,7 +48,7 @@ describe('mock for claims', () => {
         it('valid wallet', async () => {
             const address = 'evmos1gpapf6d8v85vwsl4w36n8l5qlchhp2j2drdyxg'
             await mockServer
-                .forGet(`/evmos/claims/v1/claims_record/${address}`)
+                .forGet(`/evmos/claims/v1/claims_records/${address}`)
                 .thenReply(
                     200,
                     JSON.stringify({
@@ -110,7 +110,7 @@ describe('mock for claims', () => {
         it('invalid wallet', async () => {
             const address = 'evmos1gpapf6d8v85vwsl4w36n8l5qlchhp2j2drdyxgq'
             await mockServer
-                .forGet(`/evmos/claims/v1/claims_record/${address}`)
+                .forGet(`/evmos/claims/v1/claims_records/${address}`)
                 .thenReply(400, '')
             const response = await getClaimsRecord(rest, address)
             expect(response).toStrictEqual({
@@ -124,7 +124,7 @@ describe('mock for claims', () => {
         it('wallet with no records', async () => {
             const address = 'evmos1qc3xt7vctgwesrlfytve5yja8qcja4tcjkxemy'
             await mockServer
-                .forGet(`/evmos/claims/v1/claims_record/${address}`)
+                .forGet(`/evmos/claims/v1/claims_records/${address}`)
                 .thenReply(404, '')
             const response = await getClaimsRecord(rest, address)
             expect(response).toStrictEqual({


### PR DESCRIPTION
It appears the url path changed for the claims endpoint. It use to be claims_record, but now it's claims_records. This pr corrects that.